### PR TITLE
Implement parameters for configure output of the request and response issue #41

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -351,14 +351,18 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("RESPONSE_OUTPUT_FORMAT")
                 .long("response-output-format")
+                .short("s")
                 .default_value("%R\n%H\n%B\n")
-                .help("Define the format for print the response, possible options %R response line, %H headers, %B body")
+                .hide_default_value(true)
+                .help("Define the format for print the response, possible options %R response line, %H headers, %B body \n[default: %R\\n%H\\n%N\\n]")
         )
         .arg(
             Arg::with_name("REQUEST_OUTPUT_FORMAT")
                 .long("request-output-format")
+                .short("q")
                 .default_value("%R\n\n")
-                .help("Define the format for print the request, possible options %R request line, %H headers, %B body")
+                .hide_default_value(true)
+                .help("Define the format for print the request, possible options %R request line, %H headers, %B body \n[default: %R\\n\\n]")
         )
         .usage("dot-http [OPTIONS] <FILE>")
         .get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,7 +296,7 @@
 
 use anyhow::Result;
 use clap::{App, Arg};
-use dot_http::output::print::PrintOutputter;
+use dot_http::output::{parse_format, print::FormattedOutputter};
 use dot_http::{ClientConfig, Runtime};
 use std::borrow::BorrowMut;
 use std::io::stdout;
@@ -348,6 +348,18 @@ fn main() -> Result<()> {
                 .long("danger-accept-invalid-certs")
                 .help("Controls the use of certificate validation."),
         )
+        .arg(
+            Arg::with_name("RESPONSE_OUTPUT_FORMAT")
+                .long("response-output-format")
+                .default_value("%R\n%H\n%B\n")
+                .help("Define the format for print the response, possible options %R response line, %H headers, %B body")
+        )
+        .arg(
+            Arg::with_name("REQUEST_OUTPUT_FORMAT")
+                .long("request-output-format")
+                .default_value("%R\n\n")
+                .help("Define the format for print the request, possible options %R request line, %H headers, %B body")
+        )
         .usage("dot-http [OPTIONS] <FILE>")
         .get_matches();
 
@@ -358,10 +370,18 @@ fn main() -> Result<()> {
     let env_file = matches.value_of("ENV_FILE").unwrap();
     let snapshot_file = matches.value_of("SNAPSHOT_FILE").unwrap();
     let ignore_certificates: bool = matches.is_present("IGNORE_CERT");
+    let response_format = matches.value_of("RESPONSE_OUTPUT_FORMAT").unwrap();
+    let request_format = matches.value_of("REQUEST_OUTPUT_FORMAT").unwrap();
+
+    let client_config = ClientConfig::new(!ignore_certificates);
 
     let mut stdout = stdout();
-    let mut outputter = PrintOutputter::new(stdout.borrow_mut());
-    let client_config = ClientConfig::new(!ignore_certificates);
+    let mut outputter = FormattedOutputter::new(
+        stdout.borrow_mut(),
+        parse_format(request_format)?,
+        parse_format(response_format)?,
+    );
+
     let mut runtime = Runtime::new(
         env,
         Path::new(snapshot_file),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 use crate::{Method, Request, Response, Result, Version};
 use std::fmt;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum FormatItem {
     FirstLine,
     Headers,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,6 +6,49 @@ mod tests;
 use crate::{Method, Request, Response, Result, Version};
 use std::fmt;
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum FormatItem {
+    FirstLine,
+    Headers,
+    Body,
+    Chars(String),
+}
+
+pub fn parse_format(format: &str) -> Result<Vec<FormatItem>> {
+    let mut result = Vec::new();
+    let mut marker = false;
+    let mut buff = String::new();
+    for ch in format.chars() {
+        if marker {
+            marker = false;
+            let action = match ch {
+                '%' => None,
+                'R' => Some(FormatItem::FirstLine),
+                'H' => Some(FormatItem::Headers),
+                'B' => Some(FormatItem::Body),
+                _ => return Err(anyhow!("Invalid formatting character '{}'", ch)),
+            };
+            if let Some(a) = action {
+                if buff.len() > 0 {
+                    result.push(FormatItem::Chars(buff));
+                    result.push(a);
+                    buff = String::new();
+                }
+            } else {
+                buff.push(ch);
+            }
+        } else if ch == '%' {
+            marker = true;
+        } else {
+            buff.push(ch);
+        }
+    }
+    if buff.len() > 0 {
+        result.push(FormatItem::Chars(buff));
+    }
+    Ok(result)
+}
+
 fn prettify_response_body(body: &str) -> String {
     match serde_json::from_str(body) {
         Ok(serde_json::Value::Object(response_body)) => {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -29,7 +29,7 @@ pub fn parse_format(format: &str) -> Result<Vec<FormatItem>> {
                 _ => return Err(anyhow!("Invalid formatting character '{}'", ch)),
             };
             if let Some(a) = action {
-                if buff.len() > 0 {
+                if !buff.is_empty() {
                     result.push(FormatItem::Chars(buff));
                     buff = String::new();
                 }
@@ -43,7 +43,7 @@ pub fn parse_format(format: &str) -> Result<Vec<FormatItem>> {
             buff.push(ch);
         }
     }
-    if buff.len() > 0 {
+    if !buff.is_empty() {
         result.push(FormatItem::Chars(buff));
     }
     Ok(result)

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -31,9 +31,9 @@ pub fn parse_format(format: &str) -> Result<Vec<FormatItem>> {
             if let Some(a) = action {
                 if buff.len() > 0 {
                     result.push(FormatItem::Chars(buff));
-                    result.push(a);
                     buff = String::new();
                 }
+                result.push(a);
             } else {
                 buff.push(ch);
             }

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -80,4 +80,3 @@ impl<'a, W: Write> Outputter for FormattedOutputter<'a, W> {
         Ok(())
     }
 }
-

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -1,7 +1,87 @@
-use crate::output::{prettify_response_body, Outputter};
+use crate::output::{prettify_response_body, FormatItem, Outputter};
 use crate::{Request, Response, Result};
 use std::io::Write;
 use std::ops::Add;
+
+pub struct FormattedOutputter<'a, W: Write> {
+    writer: &'a mut W,
+    request_format: Vec<FormatItem>,
+    response_format: Vec<FormatItem>,
+}
+
+impl<'a, W: Write> FormattedOutputter<'a, W> {
+    pub fn new(
+        writer: &mut W,
+        request_format: Vec<FormatItem>,
+        response_format: Vec<FormatItem>,
+    ) -> FormattedOutputter<W> {
+        FormattedOutputter {
+            writer,
+            request_format,
+            response_format,
+        }
+    }
+}
+
+fn format_headers(headers: &[(String, String)]) -> String {
+    headers
+        .iter()
+        .map(|(key, value)| format!("\n{}: {}", key, value))
+        .collect()
+}
+
+fn format_body(body: &Option<String>) -> String {
+    match body {
+        Some(body) => String::from("\n\n")
+            .add(&prettify_response_body(&body))
+            .add("\n"),
+        None => String::from(""),
+    }
+}
+
+impl<'a, W: Write> Outputter for FormattedOutputter<'a, W> {
+    fn response(&mut self, response: &Response) -> Result<()> {
+        let Response {
+            headers,
+            version,
+            status,
+            body,
+            ..
+        } = response;
+
+        for format_item in &self.response_format {
+            let to_write = match format_item {
+                FormatItem::FirstLine => format!("{} {}", version, status),
+                FormatItem::Headers => format!("{}", format_headers(headers)),
+                FormatItem::Body => format!("{}", format_body(body)),
+                FormatItem::Chars(s) => s.clone(),
+            };
+
+            self.writer.write_all(to_write.as_bytes())?;
+        }
+        Ok(())
+    }
+    fn request(&mut self, request: &Request) -> Result<()> {
+        let Request {
+            method,
+            target,
+            headers,
+            body,
+            ..
+        } = request;
+        for format_item in &self.request_format {
+            let to_write = match format_item {
+                FormatItem::FirstLine => format!("{} {}", method, target),
+                FormatItem::Headers => format!("{}", format_headers(headers)),
+                FormatItem::Body => format!("{}", format_body(body)),
+                FormatItem::Chars(s) => s.clone(),
+            };
+
+            self.writer.write_all(to_write.as_bytes())?;
+        }
+        Ok(())
+    }
+}
 
 pub struct PrintOutputter<'a, W: Write> {
     writer: &'a mut W,

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -26,15 +26,13 @@ impl<'a, W: Write> FormattedOutputter<'a, W> {
 fn format_headers(headers: &[(String, String)]) -> String {
     headers
         .iter()
-        .map(|(key, value)| format!("\n{}: {}", key, value))
+        .map(|(key, value)| format!("{}: {}\n", key, value))
         .collect()
 }
 
 fn format_body(body: &Option<String>) -> String {
     match body {
-        Some(body) => String::from("\n\n")
-            .add(&prettify_response_body(&body))
-            .add("\n"),
+        Some(body) => prettify_response_body(&body),
         None => String::from(""),
     }
 }
@@ -69,6 +67,7 @@ impl<'a, W: Write> Outputter for FormattedOutputter<'a, W> {
             body,
             ..
         } = request;
+
         for format_item in &self.request_format {
             let to_write = match format_item {
                 FormatItem::FirstLine => format!("{} {}", method, target),

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -1,7 +1,6 @@
 use crate::output::{prettify_response_body, FormatItem, Outputter};
 use crate::{Request, Response, Result};
 use std::io::Write;
-use std::ops::Add;
 
 pub struct FormattedOutputter<'a, W: Write> {
     writer: &'a mut W,
@@ -82,56 +81,3 @@ impl<'a, W: Write> Outputter for FormattedOutputter<'a, W> {
     }
 }
 
-pub struct PrintOutputter<'a, W: Write> {
-    writer: &'a mut W,
-}
-
-impl<'a, W: Write> PrintOutputter<'a, W> {
-    pub fn new(writer: &mut W) -> PrintOutputter<W> {
-        PrintOutputter { writer }
-    }
-}
-
-impl<'a, W: Write> Outputter for PrintOutputter<'a, W> {
-    fn response(&mut self, response: &Response) -> Result<()> {
-        let Response {
-            headers,
-            version,
-            status,
-            body,
-            ..
-        } = response;
-
-        let headers: String = headers
-            .iter()
-            .map(|(key, value)| format!("\n{}: {}", key, value))
-            .collect();
-        let response = format!(
-            "\
-{http_version} {status}\
-{headers}\
-{body}\
-            ",
-            http_version = version,
-            status = status,
-            headers = headers,
-            body = match body {
-                Some(body) => String::from("\n\n")
-                    .add(&prettify_response_body(&body))
-                    .add("\n"),
-                None => String::from(""),
-            }
-        );
-
-        self.writer.write_all(response.as_bytes())?;
-
-        Ok(())
-    }
-
-    fn request(&mut self, request: &Request) -> Result<()> {
-        let Request { method, target, .. } = request;
-        let request = format!("{method} {target}\n", method = method, target = target);
-        self.writer.write_all(request.as_bytes())?;
-        Ok(())
-    }
-}

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -49,8 +49,8 @@ impl<'a, W: Write> Outputter for FormattedOutputter<'a, W> {
         for format_item in &self.response_format {
             let to_write = match format_item {
                 FormatItem::FirstLine => format!("{} {}", version, status),
-                FormatItem::Headers => format!("{}", format_headers(headers)),
-                FormatItem::Body => format!("{}", format_body(body)),
+                FormatItem::Headers => format_headers(headers),
+                FormatItem::Body => format_body(body),
                 FormatItem::Chars(s) => s.clone(),
             };
 
@@ -70,8 +70,8 @@ impl<'a, W: Write> Outputter for FormattedOutputter<'a, W> {
         for format_item in &self.request_format {
             let to_write = match format_item {
                 FormatItem::FirstLine => format!("{} {}", method, target),
-                FormatItem::Headers => format!("{}", format_headers(headers)),
-                FormatItem::Body => format!("{}", format_body(body)),
+                FormatItem::Headers => format_headers(headers),
+                FormatItem::Body => format_body(body),
                 FormatItem::Chars(s) => s.clone(),
             };
 

--- a/src/output/tests.rs
+++ b/src/output/tests.rs
@@ -1,4 +1,4 @@
-use crate::output::prettify_response_body;
+use crate::output::{parse_format, prettify_response_body, FormatItem};
 
 #[test]
 fn output_is_prettified() {
@@ -17,4 +17,27 @@ fn output_is_prettified() {
         .trim(),
         pretty_body
     );
+}
+
+#[test]
+fn format_parsing_test() {
+    let result = parse_format("a%R,%H,%B");
+    assert_eq!(
+        result.expect("parse correctly"),
+        vec![
+            FormatItem::Chars("a".into()),
+            FormatItem::FirstLine,
+            FormatItem::Chars(",".into()),
+            FormatItem::Headers,
+            FormatItem::Chars(",".into()),
+            FormatItem::Body
+        ]
+    );
+
+    let result = parse_format("a%X");
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Invalid formatting character 'X'"
+    )
 }

--- a/src/output/tests.rs
+++ b/src/output/tests.rs
@@ -39,5 +39,10 @@ fn format_parsing_test() {
     assert_eq!(
         result.unwrap_err().to_string(),
         "Invalid formatting character 'X'"
-    )
+    );
+    let result = parse_format("%R");
+    assert_eq!(
+        result.expect("parse correctly"),
+        vec![FormatItem::FirstLine,]
+    );
 }

--- a/src/output/tests.rs
+++ b/src/output/tests.rs
@@ -1,4 +1,9 @@
-use crate::output::{parse_format, prettify_response_body, FormatItem};
+use crate::{
+    output::{
+        parse_format, prettify_response_body, print::FormattedOutputter, FormatItem, Outputter,
+    },
+    Method, Request, Response, Version,
+};
 
 #[test]
 fn output_is_prettified() {
@@ -44,5 +49,88 @@ fn format_parsing_test() {
     assert_eq!(
         result.expect("parse correctly"),
         vec![FormatItem::FirstLine,]
+    );
+}
+#[test]
+fn test_format_request() {
+    let request = Request {
+        method: Method::Get,
+        target: "localhost:8080".to_string(),
+        headers: vec![("Content-Type".to_string(), "text/json".to_string())],
+        body: Some("{\"req\":\"great\"}".to_string()),
+    };
+    let response = Response {
+        status_code: 200,
+        status: "200 Ok".to_string(),
+        version: Version::Http11,
+        headers: vec![("Content-Type".to_string(), "text/json".to_string())],
+        body: Some("{\"resp\":\"great-resp\"}".to_string()),
+    };
+    let empty_format = parse_format("").expect("valid format");
+
+    let mut buffer = Vec::new();
+    let mut empty_output = FormattedOutputter::new(&mut buffer, empty_format.clone(), empty_format);
+    empty_output
+        .request(&request)
+        .expect("print works correctly");
+    empty_output
+        .response(&response)
+        .expect("print works correctly");
+    assert_eq!(String::from_utf8(buffer).expect("is a string"), "");
+
+    let full_format = parse_format("%R\n%H\n%B\n").expect("valid format");
+    let mut buffer = Vec::new();
+    let mut outputter = FormattedOutputter::new(&mut buffer, full_format.clone(), full_format);
+    outputter.request(&request).expect("print works correctly");
+    outputter
+        .response(&response)
+        .expect("print works correctly");
+    assert_eq!(
+        String::from_utf8(buffer).expect("is a string"),
+        r#"GET localhost:8080
+Content-Type: text/json
+
+{
+  "req": "great"
+}
+HTTP/1.1 200 Ok
+Content-Type: text/json
+
+{
+  "resp": "great-resp"
+}
+"#
+    );
+
+    let first_line_headers = parse_format("%R\n%H\n").expect("valid format");
+    let mut buffer = Vec::new();
+    let mut outputter =
+        FormattedOutputter::new(&mut buffer, first_line_headers.clone(), first_line_headers);
+    outputter.request(&request).expect("print works correctly");
+    outputter
+        .response(&response)
+        .expect("print works correctly");
+    assert_eq!(
+        String::from_utf8(buffer).expect("is a string"),
+        r#"GET localhost:8080
+Content-Type: text/json
+
+HTTP/1.1 200 Ok
+Content-Type: text/json
+
+"#
+    );
+
+    let only_first_line = parse_format("%R\n").expect("valid format");
+    let mut buffer = Vec::new();
+    let mut outputter =
+        FormattedOutputter::new(&mut buffer, only_first_line.clone(), only_first_line);
+    outputter.request(&request).expect("print works correctly");
+    outputter
+        .response(&response)
+        .expect("print works correctly");
+    assert_eq!(
+        String::from_utf8(buffer).expect("is a string"),
+        "GET localhost:8080\nHTTP/1.1 200 Ok\n"
     );
 }

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -1,5 +1,6 @@
 use crate::common::{create_file, DebugWriter};
-use dot_http::output::print::PrintOutputter;
+use dot_http::output::parse_format;
+use dot_http::output::print::FormattedOutputter;
 use dot_http::{ClientConfig, Runtime};
 use httpmock::{Mock, MockServer};
 use std::borrow::BorrowMut;
@@ -54,7 +55,13 @@ GET http://localhost:{port}/multi_get_third\
         port = server.port(),
     ));
     let writer = &mut DebugWriter(String::new());
-    let mut outputter = PrintOutputter::new(writer);
+    let request_format = "%R\n";
+    let response_format = "%R\n%H\n%B\n";
+    let mut outputter = FormattedOutputter::new(
+        writer,
+        parse_format(request_format).unwrap(),
+        parse_format(response_format).unwrap(),
+    );
 
     let mut runtime = Runtime::new(
         env,
@@ -93,7 +100,7 @@ GET http://localhost:{port}/multi_get_third
 HTTP/1.1 204 No Content
 date: \n\
 content-length: 0\
-            ",
+\n\n\n",
             port = server.port()
         )
     );

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,5 +1,6 @@
 use crate::common::{create_file, DebugWriter};
-use dot_http::output::print::PrintOutputter;
+use dot_http::output::parse_format;
+use dot_http::output::print::FormattedOutputter;
 use dot_http::{ClientConfig, Runtime};
 use httpmock::{Mock, MockServer};
 use std::borrow::BorrowMut;
@@ -25,7 +26,13 @@ fn simple_get() {
         port = server.port()
     ));
     let writer = &mut DebugWriter(String::new());
-    let mut outputter = PrintOutputter::new(writer);
+    let request_format = "%R\n";
+    let response_format = "%R\n%H\n%B\n";
+    let mut outputter = FormattedOutputter::new(
+        writer,
+        parse_format(request_format).unwrap(),
+        parse_format(response_format).unwrap(),
+    );
 
     let mut runtime = Runtime::new(
         env,
@@ -47,7 +54,7 @@ GET http://localhost:{}/simple_get/30
 HTTP/1.1 200 OK
 date: \n\
 content-length: 0\
-            ",
+\n\n\n",
             server.port()
         )
     );
@@ -79,7 +86,13 @@ POST http://localhost:{port}/simple_post
         port = server.port(),
     ));
     let writer = &mut DebugWriter(String::new());
-    let mut outputter = PrintOutputter::new(writer);
+    let request_format = "%R\n";
+    let response_format = "%R\n%H\n%B\n";
+    let mut outputter = FormattedOutputter::new(
+        writer,
+        parse_format(request_format).unwrap(),
+        parse_format(response_format).unwrap(),
+    );
 
     let mut runtime = Runtime::new(
         env,


### PR DESCRIPTION
This is a first implementation that provide two new parameters `--request-output-format` and `--response-output-format` for now support only `%R` for the request/response line, `%H` for the headers and `%B` for the body, the options are case sensitive.

The "escaped characters" like `\n` it often depend on the shell, I still need to investigate how to support them properly any suggestion is welcome.

also I put there two options one for request and one for response, because also print computed informations of the request can be useful, feedback on this is also welcome.

Regards
