### PR TITLE
Allowed request_separator before first request in script

### DIFF
--- a/src/parser/parser.pest
+++ b/src/parser/parser.pest
@@ -33,4 +33,4 @@ header_field = ${ field_name ~ ":" ~ SP* ~ field_value}
 field_name = { token }
 field_value = { (!CRLF ~ (inline_script | ANY))* }
 
-file = { SOI ~ CRLF* ~ (request_script ~ CRLF* ~ ((request_separator ~ CRLF*) | EOI))* ~ EOI }
+file = { SOI ~ (request_separator ~ CRLF | CRLF*) ~ (request_script ~ CRLF* ~ ((request_separator ~ CRLF*) | EOI))* ~ EOI }


### PR DESCRIPTION
Allowing autogenerated first line comment from IntelliJ http client ([Issue 63](https://github.com/bayne/dot-http/issues/63))