### PR TITLE
Clippy warnings

### DIFF
--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -31,7 +31,7 @@ fn format_headers(headers: &[(String, String)]) -> String {
 
 fn format_body(body: &Option<String>) -> String {
     match body {
-        Some(body) => prettify_response_body(&body),
+        Some(body) => prettify_response_body(body),
         None => String::from(""),
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,10 +31,10 @@ impl fmt::Display for Error {
 }
 
 fn invalid_pair(expected: Rule, got: Rule) -> ! {
-    panic!("{}", format!(
-        "Wrong pair. Expected: {:?}, Got: {:?}",
-        expected, got
-    ))
+    panic!(
+        "{}",
+        format!("Wrong pair. Expected: {:?}, Got: {:?}", expected, got)
+    )
 }
 
 trait FromPair {
@@ -105,7 +105,7 @@ impl FromPair for Method {
                 "PUT" => Method::Put(selection),
                 "PATCH" => Method::Patch(selection),
                 "OPTIONS" => Method::Options(selection),
-                _ => panic!("{}",format!("Unsupported method: {}", pair.as_str())),
+                _ => panic!("{}", format!("Unsupported method: {}", pair.as_str())),
             },
             _ => invalid_pair(Rule::method, pair.as_rule()),
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,7 +31,7 @@ impl fmt::Display for Error {
 }
 
 fn invalid_pair(expected: Rule, got: Rule) -> ! {
-    panic!(format!(
+    panic!("{}", format!(
         "Wrong pair. Expected: {:?}, Got: {:?}",
         expected, got
     ))
@@ -105,7 +105,7 @@ impl FromPair for Method {
                 "PUT" => Method::Put(selection),
                 "PATCH" => Method::Patch(selection),
                 "OPTIONS" => Method::Options(selection),
-                _ => panic!(format!("Unsupported method: {}", pair.as_str())),
+                _ => panic!("{}",format!("Unsupported method: {}", pair.as_str())),
             },
             _ => invalid_pair(Rule::method, pair.as_rule()),
         }
@@ -221,11 +221,7 @@ impl FromPair for Request {
                             Rule::request_body => Some(pair),
                             _ => None,
                         });
-                        if let Some(pair) = pair {
-                            Some(Value::from_pair(filename, pair))
-                        } else {
-                            None
-                        }
+                        pair.map(|pair| Value::from_pair(filename, pair))
                     },
                 }
             }
@@ -247,11 +243,7 @@ impl FromPair for RequestScript {
                             Rule::response_handler => Some(pair),
                             _ => None,
                         });
-                        if let Some(pair) = pair {
-                            Some(Handler::from_pair(filename, pair))
-                        } else {
-                            None
-                        }
+                        pair.map(|pair| Handler::from_pair(filename, pair))
                     },
                 }
             }
@@ -307,8 +299,8 @@ pub fn parse(filename: PathBuf, source: &str) -> Result<File> {
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.state {
-            Unprocessed::WithInline { value, .. } => f.write_str(&value),
-            Unprocessed::WithoutInline(value, _) => f.write_str(&value),
+            Unprocessed::WithInline { value, .. } => f.write_str(value),
+            Unprocessed::WithoutInline(value, _) => f.write_str(value),
         }
     }
 }

--- a/src/parser/parser.pest
+++ b/src/parser/parser.pest
@@ -33,4 +33,4 @@ header_field = ${ field_name ~ ":" ~ SP* ~ field_value}
 field_name = { token }
 field_value = { (!CRLF ~ (inline_script | ANY))* }
 
-file = { SOI ~ CRLF* ~ (request_script ~ CRLF* ~ ((request_separator ~ CRLF*) | EOI))* ~ EOI }
+file = { SOI ~ (request_separator ~ CRLF | CRLF*) ~ (request_script ~ CRLF* ~ ((request_separator ~ CRLF*) | EOI))* ~ EOI }

--- a/src/script_engine/mod.rs
+++ b/src/script_engine/mod.rs
@@ -182,7 +182,7 @@ fn handle(
     response: &crate::Response,
 ) -> Result<()> {
     inject(engine, response)?;
-    engine.execute_script(&script)?;
+    engine.execute_script(script)?;
     Ok(())
 }
 


### PR DESCRIPTION
This contains the same fixes as [PR62](https://github.com/bayne/dot-http/pull/62) by @tglman but with a couple more recent extras. I have attempted to test on old versions and it seems to be mostly compatible. 

Maybe moving to a more recent rust version might be wise?