### PR TITLE
Update README.md to include link to Emacs mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ rustup run stable cargo install dot-http
 
 See `dot-http --help` for usage.
 
-### Vim
+### Editor Support
 
-See this [plugin](https://github.com/bayne/vim-dot-http) to use dot-http within vim.
+See these plugins to use dot-http within your editor
+
+- [Vim](https://github.com/bayne/vim-dot-http)
+- [Emacs](https://github.com/mschloesser/dot-http-mode)
 
 ### The request
 


### PR DESCRIPTION
I created a simple Emacs mode for dot-http (work in progress). It would be great if you could merge my change to REAMDE.md so that a link to the repo is shown there next to the Vim plugin.